### PR TITLE
Changes to Filter Wheel Motion for Zero Second Flat Exposures

### DIFF
--- a/lib/acquire.py
+++ b/lib/acquire.py
@@ -317,10 +317,10 @@ class SpotTestCoordinator(BiasPlusImagesTestCoordinator):
                 self.flatexposure = float(flatexposure)
                 def expose_command():
                     self.set_filter(self.mask)
-                    bot_bench.openShutter(self.spotexposure) # spot mask
-                    self.set_filter('empty6') # empty1 was used for `grid'
+                    bot_bench.openShutter(self.spotexposure)
                     if self.flatexposure != 0.:
-                        bot_bench.openShutter(self.flatexposure) # flat
+                        self.set_filter('empty6')
+                        bot_bench.openShutter(self.flatexposure)
                 for i in range(self.imcount):
                     self.take_bias_plus_image(self.spotexposure, expose_command, symlink_image_type='%03.1f_%03.1f_FLAT_%s_%03.1f_%03.1f' % (x, y, self.mask, self.spotexposure, self.flatexposure))
 


### PR DESCRIPTION
Moved the second `set_filter()` within the zero exposure time logic check for the flat field exposure half of the spot/flat acquisitions.